### PR TITLE
2nd error print, printed the first error

### DIFF
--- a/RealmTest/DBRealmMigrationHelper.m
+++ b/RealmTest/DBRealmMigrationHelper.m
@@ -40,8 +40,9 @@
         RLMRealmConfiguration *config = [DBRealmModel1 realmConfiguration];
         NSLog(@"Schema version = %@", @(config.schemaVersion));
 //        [RLMRealm realmWithConfiguration:config error:&error];
-        [RLMRealm realmWithConfiguration:config error:NULL];
-        NSLog(@"Error %@", error.localizedDescription);
+        NSError *error1 = nil;
+        [RLMRealm realmWithConfiguration:config error:&error1];
+        NSLog(@"Error %@", error1.localizedDescription);
 //        [RLMRealm realmWithConfiguration:[DBRealmModel2 realmConfiguration] error: &error];
         [RLMRealm realmWithConfiguration:[DBRealmModel2 realmConfiguration] error: NULL];
         NSLog(@"Error %@", error.localizedDescription);


### PR DESCRIPTION
No error pointer was passed in before. That means if opening a Realm with configuration retrieved via `DBRealmModel1` would have caused an error, you wouldn't have seen any 2nd or 3rd error print on the console. But instead it succeeds, as expected, and prints the error which happened when trying to migrate the default.realm with a to low schema version.
